### PR TITLE
fix: correct example command syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ cargo build --release
 
 ```bash
 # TCP client example
-cargo run --example tcp_client
+cargo run --example tcp-client
 
 # Kaonic mesh test client
-cargo run --example kaonic_client
+cargo run --example kaonic-client
 ```
 
 ## Use Cases


### PR DESCRIPTION
This PR is meant to fix the typo in the command syntax example of the README.md