### PR TITLE
feat: make protobuf dependencies optional and update documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,9 @@ constrained deployments with maximum performance and minimal dependencies.
 
 [dependencies]
 
-# Protobuf and gRPC
-tonic = "0.13.0"
-prost = "0.13.5"
+# Protobuf and gRPC (optional)
+tonic = { version = "0.13.0", optional = true }
+prost = { version = "0.13.5", optional = true }
 
 # Crypto
 crypto-common = { version = "0.1.6", features = ["rand_core"] }
@@ -50,13 +50,14 @@ serde = { version = "1.0.219", features = ["derive"] }
 log = "0.4.27"
 env_logger = "0.10"
 
+[build-dependencies]
+tonic-build = { version = "0.13.0", optional = true }
+
 [features]
 default = ["alloc"]
 alloc = []
 fernet-aes128 = []
-
-[build-dependencies]
-tonic-build = "0.13.0"
+protobuf = ["dep:tonic", "dep:prost", "dep:tonic-build"]
 
 [[example]]
 name = "tcp-server"
@@ -77,6 +78,7 @@ path = "examples/link_client.rs"
 [[example]]
 name = "kaonic-client"
 path = "examples/kaonic_client.rs"
+required-features = ["protobuf"]
 
 [[example]]
 name = "testnet-client"
@@ -85,7 +87,9 @@ path = "examples/testnet_client.rs"
 [[example]]
 name = "kaonic-tcp-mesh"
 path = "examples/kaonic_tcp_mesh.rs"
+required-features = ["protobuf"]
 
 [[example]]
 name = "kaonic-mesh"
 path = "examples/kaonic_mesh.rs"
+required-features = ["protobuf"]

--- a/PROTOBUF_FEATURE_SUMMARY.md
+++ b/PROTOBUF_FEATURE_SUMMARY.md
@@ -1,0 +1,59 @@
+# Summary: Making Protobuf an Optional Feature
+
+## Changes Made
+
+This change makes protobuf dependencies (`tonic`, `prost`, and `tonic-build`) optional features rather than default dependencies. This significantly reduces the dependency footprint for users who don't need the Kaonic gRPC interface.
+
+## Files Modified
+
+### Cargo.toml
+- Made `tonic`, `prost`, and `tonic-build` optional dependencies
+- Added new `protobuf` feature that enables these dependencies
+- Updated kaonic examples to require the `protobuf` feature
+
+### build.rs
+- Wrapped protobuf compilation in `#[cfg(feature = "protobuf")]` 
+- Now only builds proto files when the feature is enabled
+
+### src/iface.rs
+- Made kaonic module conditional on `protobuf` feature
+
+### src/iface/kaonic.rs
+- Added feature guards for kaonic-specific types and implementations
+
+### src/iface/kaonic/kaonic_grpc.rs
+- Wrapped entire module content in feature guards
+
+### README.md
+- Updated documentation to explain the new optional feature
+- Updated build and example instructions
+
+## Usage
+
+### Without protobuf (default):
+```bash
+cargo build                           # Minimal dependencies
+cargo run --example tcp_client        # Works without protobuf
+```
+
+### With protobuf:
+```bash
+cargo build --features protobuf       # Includes protobuf dependencies
+cargo run --example kaonic_client --features protobuf
+```
+
+## Benefits
+
+1. **Reduced dependency footprint**: Default build only includes core networking dependencies
+2. **Faster compilation**: Users not needing Kaonic support get faster builds
+3. **Embedded-friendly**: Better suited for resource-constrained environments
+4. **Backwards compatible**: Existing code using Kaonic just needs to enable the feature
+
+## Testing
+
+- ✅ Library builds without protobuf feature
+- ✅ Library builds with protobuf feature
+- ✅ Kaonic examples require protobuf feature 
+- ✅ Non-kaonic examples work without protobuf feature
+- ✅ All tests pass with and without the feature
+- ✅ Documentation builds correctly

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ This project brings Reticulum's capabilities to the Rust ecosystem, enabling emb
 - 🔌 Easily embeddable in embedded devices and tactical radios
 - 🧪 Example clients for testnets and real deployments
 
+### Optional Features
+
+- **protobuf**: Enables Protocol Buffers support for Kaonic gRPC interface (disabled by default)
+
 ## Structure
 
 
@@ -48,22 +52,26 @@ Reticulum-rs/
 ### Prerequisites
 
 * Rust (edition 2021+)
-* `protoc` for compiling `.proto` files (if using gRPC/Kaonic modules)
+* `protoc` for compiling `.proto` files (if using protobuf feature for Kaonic modules)
 
 ### Build
 
 ```bash
+# Basic build (without protobuf support)
 cargo build --release
+
+# Build with protobuf support for Kaonic interfaces
+cargo build --release --features protobuf
 ```
 
 ### Run Examples
 
 ```bash
-# TCP client example
+# TCP client example (works without protobuf feature)
 cargo run --example tcp-client
 
-# Kaonic mesh test client
-cargo run --example kaonic-client
+# Kaonic mesh test client (requires protobuf feature)
+cargo run --example kaonic-client --features protobuf
 ```
 
 ## Use Cases

--- a/build.rs
+++ b/build.rs
@@ -1,33 +1,37 @@
 use std::io::Result;
 
 fn main() -> Result<()> {
-    println!("cargo:rerun-if-changed=proto/");
+    // Only build protobuf files when the protobuf feature is enabled
+    #[cfg(feature = "protobuf")]
+    {
+        println!("cargo:rerun-if-changed=proto/");
 
-    // Generate proto files for Kaonic
-    tonic_build::configure()
-        .type_attribute(
-            "ConfigurationRequest",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "RadioPhyConfigFSK",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "RadioPhyConfigOFDM",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "kaonic.ConfigurationRequest.phy_config",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "kaonic.ConfigurationRequest.phy_config",
-            "#[serde(tag = \"type\", content = \"data\")]",
-        )
-        .compile_protos(
-            &["proto/kaonic/kaonic.proto"],
-            &["proto/kaonic"], // The directory containing your proto files
-        )?;
+        // Generate proto files for Kaonic
+        tonic_build::configure()
+            .type_attribute(
+                "ConfigurationRequest",
+                "#[derive(serde::Deserialize, serde::Serialize)]",
+            )
+            .type_attribute(
+                "RadioPhyConfigFSK",
+                "#[derive(serde::Deserialize, serde::Serialize)]",
+            )
+            .type_attribute(
+                "RadioPhyConfigOFDM",
+                "#[derive(serde::Deserialize, serde::Serialize)]",
+            )
+            .type_attribute(
+                "kaonic.ConfigurationRequest.phy_config",
+                "#[derive(serde::Deserialize, serde::Serialize)]",
+            )
+            .type_attribute(
+                "kaonic.ConfigurationRequest.phy_config",
+                "#[serde(tag = \"type\", content = \"data\")]",
+            )
+            .compile_protos(
+                &["proto/kaonic/kaonic.proto"],
+                &["proto/kaonic"], // The directory containing your proto files
+            )?;
+    }
     Ok(())
 }

--- a/src/iface.rs
+++ b/src/iface.rs
@@ -1,5 +1,6 @@
 pub mod hdlc;
 
+#[cfg(feature = "protobuf")]
 pub mod kaonic;
 pub mod tcp_client;
 pub mod tcp_server;
@@ -189,7 +190,7 @@ impl InterfaceManager {
                     }
 
                     should_send
-                },
+                }
                 TxMessageType::Direct(address) => address == iface.address,
             };
 

--- a/src/iface/kaonic.rs
+++ b/src/iface/kaonic.rs
@@ -1,5 +1,7 @@
+#[cfg(feature = "protobuf")]
 use kaonic_grpc::proto::ConfigurationRequest;
 
+#[cfg(feature = "protobuf")]
 pub mod kaonic_grpc;
 
 pub const RADIO_FRAME_MAX_SIZE: usize = 2048usize;
@@ -10,8 +12,10 @@ pub enum RadioModule {
     RadioB = 0x01,
 }
 
+#[cfg(feature = "protobuf")]
 pub type RadioConfig = ConfigurationRequest;
 
+#[cfg(feature = "protobuf")]
 impl RadioConfig {
     pub fn new_for_module(module: RadioModule) -> Self {
         Self {

--- a/src/iface/kaonic/kaonic_grpc.rs
+++ b/src/iface/kaonic/kaonic_grpc.rs
@@ -1,37 +1,58 @@
+#[cfg(feature = "protobuf")]
 pub mod proto {
     tonic::include_proto!("kaonic");
 }
 
+#[cfg(feature = "protobuf")]
 use std::sync::Arc;
+#[cfg(feature = "protobuf")]
 use std::time::Duration;
 
+#[cfg(feature = "protobuf")]
 use proto::device_client::DeviceClient;
+#[cfg(feature = "protobuf")]
 use proto::radio_client::RadioClient;
+#[cfg(feature = "protobuf")]
 use proto::RadioFrame;
+#[cfg(feature = "protobuf")]
 use tokio::sync::mpsc::Receiver;
+#[cfg(feature = "protobuf")]
 use tokio::sync::Mutex;
+#[cfg(feature = "protobuf")]
 use tokio_stream::StreamExt;
+#[cfg(feature = "protobuf")]
 use tokio_util::sync::CancellationToken;
+#[cfg(feature = "protobuf")]
 use tonic::transport::Channel;
 
+#[cfg(feature = "protobuf")]
 use crate::buffer::{InputBuffer, OutputBuffer};
+#[cfg(feature = "protobuf")]
 use crate::error::RnsError;
+#[cfg(feature = "protobuf")]
 use crate::iface::{Interface, InterfaceContext, RxMessage};
+#[cfg(feature = "protobuf")]
 use crate::packet::Packet;
+#[cfg(feature = "protobuf")]
 use crate::serde::Serialize;
 
+#[cfg(feature = "protobuf")]
 use alloc::string::String;
 
+#[cfg(feature = "protobuf")]
 use super::RadioConfig;
 
+#[cfg(feature = "protobuf")]
 pub const KAONIC_GRPC_URL: &str = "http://192.168.10.1:8080";
 
+#[cfg(feature = "protobuf")]
 pub struct KaonicGrpc {
     addr: String,
     config: Arc<Mutex<RadioConfig>>,
     config_channel: Arc<Mutex<Option<Receiver<RadioConfig>>>>,
 }
 
+#[cfg(feature = "protobuf")]
 impl KaonicGrpc {
     pub fn new<T: Into<String>>(
         addr: T,
@@ -280,6 +301,7 @@ fn decode_frame_to_buffer<'a>(
     Ok(&buffer[..length])
 }
 
+#[cfg(feature = "protobuf")]
 impl Interface for KaonicGrpc {
     fn mtu() -> usize {
         2048


### PR DESCRIPTION
This PR is intent to make protobuf a feature an keep the reticulum core to be able to run with it.