### PR TITLE
don't break transport on duplicate packets

### DIFF
--- a/src/transport.rs
+++ b/src/transport.rs
@@ -939,7 +939,14 @@ async fn manage_transport(
                         }
 
                         if !handler.filter_duplicate_packets(&packet).await {
-                            break;
+                            log::debug!(
+                                "tp({}): dropping duplicate packet: dst={}, ctx={:?}, type={:?}",
+                                handler.config.name,
+                                packet.destination,
+                                packet.context,
+                                packet.header.packet_type
+                            );
+                            continue;
                         }
 
                         if handler.config.broadcast && packet.header.packet_type != PacketType::Announce {


### PR DESCRIPTION
The break statement here would break the entire packet task in the transport, meaning nothing would work.
KeepAlive packets for open links are also usually treated as duplicates, so this would trigger often when using links.