### PR TITLE
feat: handle LinkRTT packets

### DIFF
--- a/src/transport.rs
+++ b/src/transport.rs
@@ -491,7 +491,7 @@ async fn handle_proof<'a>(packet: &Packet, mut handler: MutexGuard<'a, Transport
 
     for link in handler.out_links.values() {
         let mut link = link.lock().await;
-        match link.handle_packet(packet) {
+        match link.handle_packet(packet, true) {
             LinkHandleResult::Activated => {
                 let rtt_packet = link.create_rtt();
                 handler.send_packet(rtt_packet).await;
@@ -561,7 +561,7 @@ async fn handle_data<'a>(packet: &Packet, handler: MutexGuard<'a, TransportHandl
     if packet.header.destination_type == DestinationType::Link {
         if let Some(link) = handler.in_links.get(&packet.destination).cloned() {
             let mut link = link.lock().await;
-            let result = link.handle_packet(packet);
+            let result = link.handle_packet(packet, false);
             match result {
                 LinkHandleResult::KeepAlive => {
                     let packet = link.keep_alive_packet(KEEP_ALIVE_RESPONSE);
@@ -573,7 +573,7 @@ async fn handle_data<'a>(packet: &Packet, handler: MutexGuard<'a, TransportHandl
 
         for link in handler.out_links.values() {
             let mut link = link.lock().await;
-            let _ = link.handle_packet(packet);
+            let _ = link.handle_packet(packet, true);
             data_handled = true;
         }
 


### PR DESCRIPTION
Handle LinkRTT packets on in_links. Without this the in_link rtt was always 0.

The reference implementation has an "initiator" flag in the Link structure. This seems to correspond to out_links in this implementation. Added an out_link flag to handle_packet and handle_data_packet to indicate whether the packet should be handled as initiator or not.