### PR TITLE
fix: use specific tokio features instead of "full"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -655,16 +655,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
-name = "lock_api"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -737,29 +727,6 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
-
-[[package]]
-name = "parking_lot"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets",
-]
 
 [[package]]
 name = "paste"
@@ -921,15 +888,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1029,12 +987,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
 name = "semver"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1073,10 +1025,11 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.5"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
+ "errno",
  "libc",
 ]
 
@@ -1179,7 +1132,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ sha2 = "0.10.8"
 rand_core = { version = "0.6.4", features = ["getrandom"] }
 
 # Async IO
-tokio = { version = "1.44.2", features = ["full"] }
+tokio = { version = "1.44.2", features = ["rt", "net", "io-util", "sync", "time", "macros"] }
 tokio-stream = "0.1.17"
 tokio-util = "0.7.15"
 
@@ -51,9 +51,11 @@ log = "0.4.27"
 env_logger = "0.10"
 
 [features]
-default = ["alloc"]
+default = ["alloc", "tokio-full"]
 alloc = []
 fernet-aes128 = []
+# Full tokio features for desktop platforms. Disable for ESP32/embedded.
+tokio-full = ["tokio/rt-multi-thread", "tokio/signal"]
 
 [build-dependencies]
 tonic-build = "0.13.0"
@@ -61,35 +63,44 @@ tonic-build = "0.13.0"
 [[example]]
 name = "tcp_server"
 path = "examples/tcp_server.rs"
+required-features = ["tokio-full"]
 
 [[example]]
 name = "tcp_client"
 path = "examples/tcp_client.rs"
+required-features = ["tokio-full"]
 
 [[example]]
 name = "udp_link"
 path = "examples/udp_link.rs"
+required-features = ["tokio-full"]
 
 [[example]]
 name = "link_client"
 path = "examples/link_client.rs"
+required-features = ["tokio-full"]
 
 [[example]]
 name = "kaonic_client"
 path = "examples/kaonic_client.rs"
+required-features = ["tokio-full"]
 
 [[example]]
 name = "testnet_client"
 path = "examples/testnet_client.rs"
+required-features = ["tokio-full"]
 
 [[example]]
 name = "kaonic_tcp_mesh"
 path = "examples/kaonic_tcp_mesh.rs"
+required-features = ["tokio-full"]
 
 [[example]]
 name = "kaonic_mesh"
 path = "examples/kaonic_mesh.rs"
+required-features = ["tokio-full"]
 
 [[example]]
 name = "multihop"
 path = "examples/multihop.rs"
+required-features = ["tokio-full"]


### PR DESCRIPTION
## Summary

- Replace `tokio = { features = ["full"] }` with specific features
- Add optional `tokio-full` feature for `rt-multi-thread` and `signal`
- Enables building reticulum-rs for embedded platforms like ESP32

## Problem

The `"full"` feature includes signal handling (`signal-hook-registry`) which uses POSIX signals not available on all platforms. Specifically, ESP-IDF's libc lacks:
- `siginfo_t`, `SIGKILL`, `SIGSTOP`
- `SA_RESTART`, `SA_SIGINFO`
- Full `sigaction` struct

This prevents reticulum-rs from compiling for ESP32 targets.

## Solution

1. Use minimal tokio features by default: `rt`, `net`, `io-util`, `sync`, `time`, `macros`
2. Add `tokio-full` feature that enables `rt-multi-thread` and `signal`
3. Include `tokio-full` in default features for backward compatibility
4. Mark examples as requiring `tokio-full` since they use `#[tokio::main]` and `tokio::signal`

## Usage

```bash
# Desktop (default) - includes rt-multi-thread and signal
cargo build

# ESP32/Embedded - minimal tokio features
cargo build --no-default-features --features alloc
```

## Testing

- ✅ Library builds with defaults (x86_64)
- ✅ Examples build with defaults (x86_64)  
- ✅ Library builds without tokio-full (ESP32 mode)
- ✅ Successfully built for ESP32-S3 (`xtensa-esp32s3-espidf` target)

🤖 Generated with [Claude Code](https://claude.com/claude-code)