### PR TITLE
feat: make gRPC support optional via "grpc" feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,9 @@ constrained deployments with maximum performance and minimal dependencies.
 
 [dependencies]
 
-# Protobuf and gRPC
-tonic = "0.13.0"
-prost = "0.13.5"
+# Protobuf and gRPC (optional, for Kaonic interface)
+tonic = { version = "0.13.0", optional = true }
+prost = { version = "0.13.5", optional = true }
 
 # Crypto
 crypto-common = { version = "0.1.6", features = ["rand_core"] }
@@ -51,12 +51,13 @@ log = "0.4.27"
 env_logger = "0.10"
 
 [features]
-default = ["alloc"]
+default = ["alloc", "grpc"]
 alloc = []
 fernet-aes128 = []
+grpc = ["dep:tonic", "dep:prost", "dep:tonic-build"]
 
 [build-dependencies]
-tonic-build = "0.13.0"
+tonic-build = { version = "0.13.0", optional = true }
 
 [[example]]
 name = "tcp_server"
@@ -77,6 +78,7 @@ path = "examples/link_client.rs"
 [[example]]
 name = "kaonic_client"
 path = "examples/kaonic_client.rs"
+required-features = ["grpc"]
 
 [[example]]
 name = "testnet_client"
@@ -85,10 +87,12 @@ path = "examples/testnet_client.rs"
 [[example]]
 name = "kaonic_tcp_mesh"
 path = "examples/kaonic_tcp_mesh.rs"
+required-features = ["grpc"]
 
 [[example]]
 name = "kaonic_mesh"
 path = "examples/kaonic_mesh.rs"
+required-features = ["grpc"]
 
 [[example]]
 name = "multihop"

--- a/build.rs
+++ b/build.rs
@@ -1,37 +1,40 @@
 use std::io::Result;
 
 fn main() -> Result<()> {
-    println!("cargo:rerun-if-changed=proto/");
+    #[cfg(feature = "grpc")]
+    {
+        println!("cargo:rerun-if-changed=proto/");
 
-    // Generate proto files for Kaonic
-    tonic_build::configure()
-        .type_attribute(
-            "ConfigurationRequest",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "RadioPhyConfigFSK",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "RadioPhyConfigOFDM",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "RadioPhyConfigQPSK",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "kaonic.ConfigurationRequest.phy_config",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "kaonic.ConfigurationRequest.phy_config",
-            "#[serde(tag = \"type\", content = \"data\")]",
-        )
-        .compile_protos(
-            &["proto/kaonic/kaonic.proto"],
-            &["proto/kaonic"], // The directory containing your proto files
-        )?;
+        // Generate proto files for Kaonic
+        tonic_build::configure()
+            .type_attribute(
+                "ConfigurationRequest",
+                "#[derive(serde::Deserialize, serde::Serialize)]",
+            )
+            .type_attribute(
+                "RadioPhyConfigFSK",
+                "#[derive(serde::Deserialize, serde::Serialize)]",
+            )
+            .type_attribute(
+                "RadioPhyConfigOFDM",
+                "#[derive(serde::Deserialize, serde::Serialize)]",
+            )
+            .type_attribute(
+                "RadioPhyConfigQPSK",
+                "#[derive(serde::Deserialize, serde::Serialize)]",
+            )
+            .type_attribute(
+                "kaonic.ConfigurationRequest.phy_config",
+                "#[derive(serde::Deserialize, serde::Serialize)]",
+            )
+            .type_attribute(
+                "kaonic.ConfigurationRequest.phy_config",
+                "#[serde(tag = \"type\", content = \"data\")]",
+            )
+            .compile_protos(
+                &["proto/kaonic/kaonic.proto"],
+                &["proto/kaonic"], // The directory containing your proto files
+            )?;
+    }
     Ok(())
 }

--- a/src/iface.rs
+++ b/src/iface.rs
@@ -1,5 +1,6 @@
 pub mod hdlc;
 
+#[cfg(feature = "grpc")]
 pub mod kaonic;
 pub mod tcp_client;
 pub mod tcp_server;


### PR DESCRIPTION
## Summary

- Adds a `grpc` feature to make tonic/prost dependencies optional
- Enables building reticulum-rs for embedded platforms without protoc

## Problem

The Kaonic interface requires tonic/prost for gRPC communication. These dependencies:
- Are heavy (increase compile time and binary size)
- Require `protoc` at build time
- Are problematic for embedded targets like ESP32

## Solution

- Add a `grpc` feature (enabled by default for backward compatibility)
- Make `tonic`, `prost`, and `tonic-build` optional dependencies
- Gate the `kaonic` module on the `grpc` feature
- Gate kaonic examples with `required-features`

## Usage

```bash
# Default build (includes gRPC, same as before)
cargo build

# Build without gRPC (no protoc required, smaller binary)
cargo build --no-default-features --features alloc
```

## Testing

- All 13 tests pass with default features
- All 13 tests pass without grpc feature
- Successfully builds for ESP32-S3 without grpc

🤖 Generated with [Claude Code](https://claude.com/claude-code)