### PR TITLE
Add daemon mode (`rnsd`) - A Rust alternative to Python Reticulum's daemon

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,9 @@ serde = { version = "1.0.219", features = ["derive"] }
 # Logging
 log = "0.4.27"
 env_logger = "0.10"
+console-subscriber = "0.5.0"
+dirs = "6.0.0"
+toml = "0.9.11"
 
 [features]
 default = ["alloc"]
@@ -93,3 +96,11 @@ path = "examples/kaonic_mesh.rs"
 [[example]]
 name = "multihop"
 path = "examples/multihop.rs"
+
+[[example]]
+name = "daemon"
+path = "examples/daemon/main.rs"
+
+[[example]]
+name = "convert_config"
+path = "examples/daemon/convert_config.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ env_logger = "0.10"
 console-subscriber = "0.5.0"
 dirs = "6.0.0"
 toml = "0.9.11"
+regex = "1.12.2"
 
 [features]
 default = ["alloc"]

--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ Reticulum-rs/
 │   ├── tcp_client.rs
 │   ├── tcp_server.rs
 │   └── testnet_client.rs
+├────── daemon/           # RNS Daemon 
+│       ├── config.rs
+│       ├── main.rs 
+│       └── convert_config.rs
+    
 ├── Cargo.toml           # Crate configuration
 ├── LICENSE              # License (MIT/Apache)
 └── build.rs             
@@ -55,6 +60,29 @@ Reticulum-rs/
 ```bash
 cargo build --release
 ```
+
+### Configuration
+
+Reticulum-rs uses TOML for configuration, whereas the original Python Reticulum uses a custom format parsed by configobj, a Python-only library. If you have an existing Python Reticulum configuration, you must convert it before use.
+
+#### Converting from Python Reticulum config
+```bash
+cargo run --example convert_config -- ~/.reticulum/config
+```
+
+This creates a backup at `~/.reticulum/config.backup` and converts the original file in place. The converter handles boolean normalization (True/False/Yes/No → true/false), quotes string values, transforms interface declarations to TOML array-of-tables syntax, and comments out None/nil values which TOML does not support.
+
+### Running the Daemon
+```bash
+# Use default config search paths (~/.config/reticulum, ~/.reticulum, /etc/reticulum)
+cargo run --example daemon
+
+# Specify a custom config directory
+cargo run --example daemon -- --config /path/to/config/dir
+cargo run --example daemon -- -c /path/to/config/dir
+```
+
+The daemon searches for either `config` (legacy filename) or `config.toml` in the specified directory.
 
 ### Run Examples
 

--- a/examples/daemon/config.rs
+++ b/examples/daemon/config.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::path;
 use std::path::PathBuf;
 use std::path::Path;
 
@@ -215,7 +216,12 @@ impl Config {
         Ok(config)
     }
 
-    pub fn load() -> Result<(Self, PathBuf), Box<dyn std::error::Error>> {
+    pub fn load(custom_config_path: Option<&Path>) -> Result<(Self, PathBuf), Box<dyn std::error::Error>> {
+        if let Some(path) = custom_config_path {
+            let config = Self::from_file(path)?;
+            return Ok((config, path.to_path_buf()));
+        }
+        
         if let Some(existing) = Self::find_existing() {
             let config = Self::from_file(&existing)?;
             Ok((config, existing))

--- a/examples/daemon/config.rs
+++ b/examples/daemon/config.rs
@@ -1,0 +1,267 @@
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use std::path::Path;
+
+#[derive(Debug, Deserialize, Serialize, Default)]
+pub struct Config {
+    #[serde(default)]
+    pub reticulum: ReticulumConfig,
+    #[serde(default)]
+    pub logging: LoggingConfig,
+    #[serde(default)]
+    pub interfaces: Vec<NamedInterface>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ReticulumConfig {
+    #[serde(default)]
+    pub enable_transport: bool,
+    #[serde(default = "default_true")]
+    pub share_instance: bool,
+    #[serde(default = "default_shared_port")]
+    pub shared_instance_port: u16,
+    #[serde(default = "default_control_port")]
+    pub instance_control_port: u16,
+    #[serde(default)]
+    pub panic_on_interface_error: bool,
+    #[serde(default)]
+    pub instance_name: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct LoggingConfig {
+    #[serde(default = "default_loglevel")]
+    pub loglevel: u8,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct NamedInterface {
+    pub name: String,
+    #[serde(flatten)]
+    pub config: InterfaceConfig,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(tag = "type")]
+pub enum InterfaceConfig {
+    TCPServerInterface {
+        #[serde(default = "default_true", alias = "interface_enabled")]
+        enabled: bool,
+        #[serde(alias = "listen_ip")]
+        bind_host: String,
+        #[serde(alias = "listen_port")]
+        bind_port: u16,
+    },
+    TCPClientInterface {
+        #[serde(default = "default_true", alias = "interface_enabled")]
+        enabled: bool,
+        target_host: String,
+        target_port: u16,
+    },
+    UDPInterface {
+        #[serde(default = "default_true", alias = "interface_enabled")]
+        enabled: bool,
+        listen_ip: String,
+        listen_port: u16,
+        forward_ip: String,
+        forward_port: u16,
+    },
+    AutoInterface {
+        #[serde(default = "default_true")]
+        enabled: bool,
+    },
+    I2PInterface {
+        #[serde(default = "default_true")]
+        enabled: bool,
+        #[serde(default)]
+        connectable: bool,
+        peers: String,
+    },
+    RNodeInterface {
+        #[serde(default = "default_true", alias = "interface_enabled")]
+        enabled: bool,
+        port: String,
+        frequency: u64,
+        bandwidth: u32,
+        txpower: u8,
+        spreadingfactor: u8,
+        codingrate: u8,
+        #[serde(default)]
+        flow_control: bool,
+    },
+    BLEInterface {
+        #[serde(default = "default_true")]
+        enabled: bool,
+        #[serde(default)]
+        enable_peripheral: bool,
+        #[serde(default)]
+        enable_central: bool,
+    },
+    KISSInterface {
+        #[serde(default = "default_true")]
+        enabled: bool,
+        port: String,
+        speed: u32,
+        databits: u8,
+        parity: String,
+        stopbits: u8,
+        preamble: u32,
+        txtail: u32,
+        persistence: u32,
+        slottime: u32,
+        #[serde(default)]
+        flow_control: bool,
+    },
+    AX25KISSInterface {
+        #[serde(default = "default_true")]
+        enabled: bool,
+        callsign: String,
+        ssid: u8,
+        port: String,
+        speed: u32,
+        databits: u8,
+        parity: String,
+        stopbits: u8,
+        preamble: u32,
+        txtail: u32,
+        persistence: u32,
+        slottime: u32,
+        #[serde(default)]
+        flow_control: bool,
+    },
+    #[serde(other)]
+    Unsupported,
+}
+
+fn default_true() -> bool { true }
+fn default_shared_port() -> u16 { 37428 }
+fn default_control_port() -> u16 { 37429 }
+fn default_loglevel() -> u8 { 4 }
+
+impl Default for ReticulumConfig {
+    fn default() -> Self {
+        Self {
+            enable_transport: false,
+            share_instance: false,
+            shared_instance_port: 37428,
+            instance_control_port: 37429,
+            panic_on_interface_error: false,
+            instance_name: None,
+        }
+    }
+}
+
+impl Default for LoggingConfig {
+    fn default() -> Self {
+        Self { loglevel: 4 }
+    }
+}
+
+impl Config {
+    pub fn search_paths() -> Vec<PathBuf> {
+        let mut paths = vec![];
+        
+        if let Some(home) = dirs::home_dir() {
+            paths.push(home.join(".config/reticulum"));
+            paths.push(home.join(".reticulum"));
+        }
+        
+        paths.push(PathBuf::from("/etc/reticulum"));
+        
+        paths
+    }
+
+    pub fn find_existing() -> Option<PathBuf> {
+        Self::search_paths()
+            .into_iter()
+            .find(|p| p.join("config").exists() || p.join("config.toml").exists())
+    }
+
+    pub fn default_path() -> PathBuf {
+        dirs::home_dir()
+            .expect("home directory")
+            .join(".config/reticulum")
+    }
+
+    pub fn from_file(path: &Path) -> Result<Self, Box<dyn std::error::Error>> {
+        let config_file = if path.join("config").exists() {
+            path.join("config")
+        } else {
+            path.join("config.toml")
+        };
+        
+        let content = std::fs::read_to_string(&config_file)?;
+        let config: Self = toml::from_str(&content).inspect_err(|_e| {
+            eprintln!();
+            eprintln!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+            eprintln!("INVALID TOML FORMAT");
+            eprintln!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+            eprintln!();
+            eprintln!("Your config file appears to be in Python Reticulum format.");
+            eprintln!("Use the converter tool to migrate it to standard TOML:");
+            eprintln!();
+            eprintln!("  cargo run --example convert_config -- {}", config_file.display());
+            eprintln!();
+            eprintln!("This will create a backup and convert your config to valid TOML.");
+            eprintln!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+            eprintln!();
+        })?;
+        
+        if config.reticulum.share_instance {
+            log::warn!("share_instance is enabled but shared instances are not supported in reticulum-rs");
+            log::warn!("Each Rust daemon process runs independently and is only limited by available ports");
+        }
+        
+        Ok(config)
+    }
+
+    pub fn load() -> Result<(Self, PathBuf), Box<dyn std::error::Error>> {
+        if let Some(existing) = Self::find_existing() {
+            let config = Self::from_file(&existing)?;
+            Ok((config, existing))
+        } else {
+            log::warn!("No existing configuration found, creating default config");
+            let default_dir = Self::default_path();
+            std::fs::create_dir_all(&default_dir)?;
+            
+            let config = Self::default_config();
+            let config_file = default_dir.join("config.toml");
+            std::fs::write(&config_file, toml::to_string_pretty(&config)?)?;
+            
+            log::warn!("Created default configuration at: {}", config_file.display());
+            log::warn!("Please review and customize the configuration for your needs");
+            
+            Ok((config, default_dir))
+        }
+    }
+
+    fn default_config() -> Self {
+        Self {
+            reticulum: ReticulumConfig::default(),
+            logging: LoggingConfig::default(),
+            interfaces: vec![
+                NamedInterface {
+                    name: "Default TCP Server Interface".to_string(),
+                    config: InterfaceConfig::TCPServerInterface {
+                        enabled: true,
+                        bind_host: "127.0.0.1".to_string(),
+                        bind_port: 4242,
+                    },
+                },
+            ],
+        }
+    }
+
+    pub fn log_filter(&self) -> &'static str {
+        match self.logging.loglevel {
+            0 => "error",
+            1 => "error",
+            2 => "warn",
+            3 => "info",
+            4 => "info",
+            5 => "debug",
+            6 => "debug",
+            _ => "trace",
+        }
+    }
+}

--- a/examples/daemon/convert_config.rs
+++ b/examples/daemon/convert_config.rs
@@ -1,0 +1,134 @@
+// examples/convert_config.rs
+use std::env;
+use std::fs;
+use std::path::Path;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = env::args().collect();
+    
+    if args.len() != 2 {
+        eprintln!("Usage: {} <config_file>", args[0]);
+        eprintln!("Example: {} ~/.reticulum/config", args[0]);
+        std::process::exit(1);
+    }
+    
+    let input_path = Path::new(&args[1]);
+    
+    if !input_path.exists() {
+        eprintln!("Error: File '{}' does not exist", input_path.display());
+        std::process::exit(1);
+    }
+    
+    println!("Reading config from: {}", input_path.display());
+    let content = fs::read_to_string(input_path)?;
+    
+    let backup_path = input_path.with_extension("backup");
+    fs::write(&backup_path, &content)?;
+    println!("Created backup at: {}", backup_path.display());
+    
+    let converted = convert_config(&content);
+    
+    fs::write(input_path, &converted)?;
+    println!("✓ Converted config written to: {}", input_path.display());
+    println!();
+    println!("Changes made:");
+    println!("  - Converted True/False/Yes/No → true/false");
+    println!("  - Quoted all string values (IPs, hostnames, paths, types)");
+    println!("  - Converted [[Interface Name]] → [[interfaces]] with name field");
+    println!("  - Normalized indentation");
+    println!("  - Preserved all comments");
+    
+    Ok(())
+}
+
+fn convert_config(content: &str) -> String {
+    let mut output = String::new();
+    
+    for line in content.lines() {
+        let trimmed = line.trim();
+        
+        // Empty lines pass through
+        if trimmed.is_empty() {
+            output.push('\n');
+            continue;
+        }
+        
+        // Skip [interfaces] header - we use [[interfaces]] instead
+        if trimmed == "[interfaces]" {
+            continue;
+        }
+        
+        // Detect interface block start
+        if trimmed.starts_with("[[") && trimmed.ends_with("]]") {
+            let name = trimmed.trim_start_matches("[[").trim_end_matches("]]").trim();
+            if name != "interfaces" {
+                // Convert [[Interface Name]] to [[interfaces]]
+                output.push_str("\n[[interfaces]]\n");
+                output.push_str(&format!("name = \"{}\"\n", name));
+                continue;
+            } else {
+                output.push_str("\n[[interfaces]]\n");
+                continue;
+            }
+        }
+        
+        // Process the line
+        let mut converted = trimmed.to_string();
+        
+        // Convert booleans
+        converted = converted.replace(" = True", " = true");
+        converted = converted.replace(" = False", " = false");
+        converted = converted.replace(" = Yes", " = true");
+        converted = converted.replace(" = yes", " = true");
+        converted = converted.replace(" = No", " = false");
+        converted = converted.replace(" = no", " = false");
+        
+        // Quote unquoted string values (only for non-comments)
+        if !converted.starts_with('#') {
+            converted = quote_if_needed(&converted, "type");
+            converted = quote_if_needed(&converted, "remote");
+            converted = quote_if_needed(&converted, "target_host");
+            converted = quote_if_needed(&converted, "bind_host");
+            converted = quote_if_needed(&converted, "listen_ip");
+            converted = quote_if_needed(&converted, "forward_ip");
+            converted = quote_if_needed(&converted, "peers");
+            converted = quote_if_needed(&converted, "instance_name");
+            converted = quote_if_needed(&converted, "port");
+            converted = quote_if_needed(&converted, "callsign");
+            converted = quote_if_needed(&converted, "parity");
+        }
+        
+        output.push_str(&converted);
+        output.push('\n');
+    }
+    
+    output
+}
+
+fn quote_if_needed(line: &str, key: &str) -> String {
+    let pattern = format!("{} = ", key);
+    let quoted_pattern = format!("{} = \"", key);
+    
+    // Already quoted or not present
+    if !line.contains(&pattern) || line.contains(&quoted_pattern) {
+        return line.to_string();
+    }
+    
+    // Find the value
+    if let Some(pos) = line.find(&pattern) {
+        let value_start = pos + pattern.len();
+        let rest = &line[value_start..];
+        let value = rest.split_whitespace().next().unwrap_or(rest).trim();
+        
+        // Don't quote numbers or booleans
+        if value.parse::<i64>().is_ok() || value.parse::<f64>().is_ok() 
+            || value == "true" || value == "false" {
+            return line.to_string();
+        }
+        
+        // Quote the value
+        format!("{}{} = \"{}\"", &line[..pos], key, value)
+    } else {
+        line.to_string()
+    }
+}

--- a/examples/daemon/main.rs
+++ b/examples/daemon/main.rs
@@ -1,0 +1,131 @@
+mod config;
+
+use config::{Config, InterfaceConfig};
+use rand_core::OsRng;
+use reticulum::identity::PrivateIdentity;
+use reticulum::iface::tcp_client::TcpClient;
+use reticulum::iface::tcp_server::TcpServer;
+use reticulum::iface::udp::UdpInterface;
+use reticulum::transport::{Transport, TransportConfig};
+use tokio::signal;
+
+struct Daemon {
+    transport: Transport,
+    config_path: std::path::PathBuf,
+}
+
+impl Daemon {
+    async fn new() -> Result<Self, Box<dyn std::error::Error>> {
+        let (config, config_path) = Config::load()?;
+
+        env_logger::Builder::from_env(
+            env_logger::Env::default().default_filter_or(config.log_filter())
+        ).init();
+
+        log::info!("Reticulum daemon starting");
+        log::info!("Configuration loaded from: {}", config_path.display());
+
+        let identity = PrivateIdentity::new_from_rand(OsRng);
+        let transport = Transport::new({
+            let mut cfg = TransportConfig::new(
+                "rns-daemon",
+                &identity,
+                config.reticulum.enable_transport,
+            );
+            cfg.set_retransmit(config.reticulum.enable_transport);
+            cfg
+        });
+
+        let iface_manager = transport.iface_manager();
+
+    for iface in config.interfaces {
+        let enabled = match &iface.config {
+            InterfaceConfig::TCPServerInterface { enabled, .. } => *enabled,
+            InterfaceConfig::TCPClientInterface { enabled, .. } => *enabled,
+            InterfaceConfig::UDPInterface { enabled, .. } => *enabled,
+            InterfaceConfig::AutoInterface { enabled, .. } => *enabled,
+            InterfaceConfig::I2PInterface { enabled, .. } => *enabled,
+            InterfaceConfig::RNodeInterface { enabled, .. } => *enabled,
+            InterfaceConfig::BLEInterface { enabled, .. } => *enabled,
+            InterfaceConfig::KISSInterface { enabled, .. } => *enabled,
+            InterfaceConfig::AX25KISSInterface { enabled, .. } => *enabled,
+            InterfaceConfig::Unsupported => false,
+        };
+    
+        if !enabled {
+            continue;
+        }
+
+        match iface.config {
+            InterfaceConfig::TCPServerInterface { bind_host, bind_port, .. } => {
+                let addr = format!("{}:{}", bind_host.trim_end_matches(':'), bind_port);
+                log::info!("Enabling interface '{}': TCP Server on {}", iface.name, addr);
+                iface_manager.lock().await.spawn(
+                    TcpServer::new(addr, iface_manager.clone()),
+                    TcpServer::spawn,
+                );
+            }
+            InterfaceConfig::TCPClientInterface { target_host, target_port, .. } => {
+                let addr = format!("{}:{}", target_host.trim_end_matches(':'), target_port);
+                log::info!("Enabling interface '{}': TCP Client to {}", iface.name, addr);
+                iface_manager.lock().await.spawn(
+                    TcpClient::new(addr),
+                    TcpClient::spawn,
+                );
+            }
+            InterfaceConfig::UDPInterface { listen_ip, listen_port, forward_ip, forward_port, .. } => {
+                let bind_addr = format!("{}:{}", listen_ip, listen_port);
+                let forward_addr = format!("{}:{}", forward_ip, forward_port);
+                log::info!("Enabling interface '{}': UDP {}→{}", iface.name, bind_addr, forward_addr);
+                iface_manager.lock().await.spawn(
+                    UdpInterface::new(bind_addr, Some(forward_addr)),
+                    UdpInterface::spawn,
+                );
+            }
+            InterfaceConfig::AutoInterface { .. } => {
+                log::warn!("Interface '{}' type 'AutoInterface' is not yet supported", iface.name);
+            }
+            InterfaceConfig::I2PInterface { .. } => {
+                log::warn!("Interface '{}' type 'I2PInterface' is not yet supported", iface.name);
+            }
+            InterfaceConfig::RNodeInterface { .. } => {
+                log::warn!("Interface '{}' type 'RNodeInterface' is not yet supported", iface.name);
+            }
+            InterfaceConfig::BLEInterface { .. } => {
+                log::warn!("Interface '{}' type 'BLEInterface' is not yet supported", iface.name);
+            }
+            InterfaceConfig::KISSInterface { .. } => {
+                log::warn!("Interface '{}' type 'KISSInterface' is not yet supported", iface.name);
+            }
+            InterfaceConfig::AX25KISSInterface { .. } => {
+                log::warn!("Interface '{}' type 'AX25KISSInterface' is not yet supported", iface.name);
+            }
+            InterfaceConfig::Unsupported => {
+                log::warn!("Interface '{}' uses an unsupported type", iface.name);
+            }
+        }
+    }
+
+        Ok(Self {
+            transport,
+            config_path,
+        })
+    }
+
+    async fn run(self) -> Result<(), Box<dyn std::error::Error>> {
+        log::info!("Reticulum instance running, interfaces initialized");
+        
+        signal::ctrl_c().await?;
+        
+        log::info!("Shutdown signal received, cleaning up");
+        drop(self.transport);
+        
+        Ok(())
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let daemon = Daemon::new().await?;
+    daemon.run().await
+}


### PR DESCRIPTION
This PR adds daemon functionality to reticulum-rs, making it possible to run a standalone Reticulum node configured through standard TOML files. I've been running this as my transport node for the past three weeks without issues.

### What works right now
The daemon reads Python Reticulum-style configuration files (after conversion) and initializes TCP and UDP interfaces. I can confirm TCPClient, TCPServer, and UDPInterface all work reliably in production. The other interface types (AutoInterface, I2PInterface, RNodeInterface, etc.) parse correctly but log warnings since they're not implemented yet.

### The configuration format problem
Python Reticulum's config format isn't actually valid TOML, even though it looks like it should be. It uses syntax like `[[Interface Name]]` with spaces, writes `Yes`/`No` instead of `true`/`false`, and leaves string values unquoted. Standard TOML parsers reject this, which is why I've included a converter tool.

If you have an existing `.reticulum/config` file, you'll need to convert it first:
```bash
cargo run --example convert_config -- ~/.reticulum/config
```

This creates a backup and rewrites your config in valid TOML. It preserves all your settings and comments, just fixes the syntax. The converted format looks like:

```toml
[[interfaces]]
name = "TCP Server Interface"
type = "TCPServerInterface"
interface_enabled = true
bind_host = "0.0.0.0"
bind_port = 4242
```

### How it finds your config
The daemon searches in this order: `~/.config/reticulum`, `~/.reticulum`, `/etc/reticulum`. This follows XDG conventions and makes it easier for distro packagers to provide system-wide defaults in `/etc` while users can override with their own configs.

If no config exists, it creates a minimal one at `~/.config/reticulum/config.toml` with a TCP server on localhost:4242.

### Open questions

Which options should the Kanoic Interface have? 

Several design decisions came up during implementation that would benefit from community input. I've opened separate issues to keep discussion focused:

- #58
- #59
- #60


None of these block the current functionality, but feedback would help guide future work.

### Testing
Beyond my own three-week run as a transport node, I've verified the conversion works with configs from `rnsd --exampleconfig` and tested that all three implemented interface types work as expected. The daemon handles interface failures gracefully and logs at appropriate levels.

This is a significant milestone since it makes reticulum-rs usable as a drop-in replacement for the Python daemon in real deployments. Looking forward to feedback and suggestions.