### PR TITLE
iface: ensure each interface's MTU is below the MDU

### DIFF
--- a/src/iface/kaonic/kaonic_grpc.rs
+++ b/src/iface/kaonic/kaonic_grpc.rs
@@ -2,6 +2,7 @@ pub mod proto {
     tonic::include_proto!("kaonic");
 }
 
+use std::cmp;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -17,7 +18,7 @@ use tonic::transport::Channel;
 use crate::buffer::{InputBuffer, OutputBuffer};
 use crate::error::RnsError;
 use crate::iface::{Interface, InterfaceContext, RxMessage};
-use crate::packet::Packet;
+use crate::packet::{Packet,PACKET_MDU};
 use crate::serde::Serialize;
 
 use alloc::string::String;
@@ -282,6 +283,7 @@ fn decode_frame_to_buffer<'a>(
 
 impl Interface for KaonicGrpc {
     fn mtu() -> usize {
-        2048
+        // XXX: Make dynamic based on iface bitrate
+        cmp::min(2048, PACKET_MDU)
     }
 }

--- a/src/iface/tcp_client.rs
+++ b/src/iface/tcp_client.rs
@@ -1,3 +1,4 @@
+use std::cmp;
 use std::sync::Arc;
 
 use tokio::io::AsyncWriteExt;
@@ -7,7 +8,7 @@ use tokio_util::sync::CancellationToken;
 use crate::buffer::{InputBuffer, OutputBuffer};
 use crate::error::RnsError;
 use crate::iface::RxMessage;
-use crate::packet::Packet;
+use crate::packet::{Packet,PACKET_MDU};
 use crate::serde::Serialize;
 
 use tokio::io::AsyncReadExt;
@@ -211,6 +212,7 @@ impl TcpClient {
 
 impl Interface for TcpClient {
     fn mtu() -> usize {
-        2048
+        // XXX: Make dynamic based on iface bitrate
+        cmp::min(2048, PACKET_MDU)
     }
 }

--- a/src/iface/tcp_server.rs
+++ b/src/iface/tcp_server.rs
@@ -1,9 +1,11 @@
 use alloc::string::String;
+use std::cmp;
 use std::sync::Arc;
 
 use tokio::net::TcpListener;
 
 use crate::error::RnsError;
+use crate::packet::PACKET_MDU;
 
 use super::tcp_client::TcpClient;
 use super::{Interface, InterfaceContext, InterfaceManager};
@@ -112,6 +114,7 @@ impl TcpServer {
 
 impl Interface for TcpServer {
     fn mtu() -> usize {
-        2048
+        // XXX: Make dynamic based on iface bitrate
+        cmp::min(2048, PACKET_MDU)
     }
 }

--- a/src/iface/udp.rs
+++ b/src/iface/udp.rs
@@ -1,3 +1,4 @@
+use std::cmp;
 use std::sync::Arc;
 
 use tokio::net::UdpSocket;
@@ -6,7 +7,7 @@ use tokio_util::sync::CancellationToken;
 use crate::buffer::{InputBuffer, OutputBuffer};
 use crate::error::RnsError;
 use crate::iface::RxMessage;
-use crate::packet::Packet;
+use crate::packet::{Packet,PACKET_MDU};
 use crate::serde::Serialize;
 
 use super::{Interface, InterfaceContext};
@@ -160,6 +161,7 @@ impl UdpInterface {
 
 impl Interface for UdpInterface {
     fn mtu() -> usize {
-        2048
+        // XXX: Make dynamic based on iface bitrate
+        cmp::min(2048, PACKET_MDU)
     }
 }

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -6,7 +6,9 @@ use crate::buffer::StaticBuffer;
 use crate::hash::AddressHash;
 use crate::hash::Hash;
 
-pub const PACKET_MDU: usize = 2048usize;
+// Maximum possible MTU
+// XXX: This technically should be 524288, but it overflows stuff atm
+pub const PACKET_MDU: usize = 8192usize;
 pub const PACKET_IFAC_MAX_LENGTH: usize = 64usize;
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]


### PR DESCRIPTION
* A step towards fixing #92
* PACKET_MDU should eventually be 524288, however the unit tests show that overflowing stuff.  Bump to 8192 to increase compatibility in the short term, while retaining functionality