### PR TITLE
TCPClientInterface: Don't stall transport traffic on down interfaces; #95

### DIFF
--- a/src/iface/tcp_client.rs
+++ b/src/iface/tcp_client.rs
@@ -50,26 +50,52 @@ impl TcpClient {
         let tx_channel = Arc::new(tokio::sync::Mutex::new(tx_channel));
 
         let mut running = true;
-        loop {
+        'outer: loop {
             if !running || context.cancel.is_cancelled() {
                 break;
             }
 
-            let stream = {
-                match stream.take() {
-                    Some(stream) => {
-                        running = false;
-                        Ok(stream)
+            let stream = match stream.take() {
+                Some(stream) => {
+                    running = false;
+                    Ok(stream)
+                }
+                None => {
+                    let mut tx_channel = tx_channel.lock().await;
+
+                    tokio::select! {
+                        biased;
+                        _ = context.cancel.cancelled() => {
+                            break;
+                        }
+                        Some(_) = tx_channel.recv() => {
+                            continue;
+                        }
+                        result = TcpStream::connect(addr.clone()) => {
+                            result.map_err(|_| RnsError::ConnectionError)
+                        }
                     }
-                    None => TcpStream::connect(addr.clone())
-                        .await
-                        .map_err(|_| RnsError::ConnectionError),
                 }
             };
 
             if let Err(_) = stream {
                 log::info!("tcp_client: couldn't connect to <{}>", addr);
-                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                let retry_at = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+
+                loop {
+                    let mut tx_channel = tx_channel.lock().await;
+
+                    tokio::select! {
+                        biased;
+                        _ = context.cancel.cancelled() => {
+                            break 'outer;
+                        }
+                        Some(_) = tx_channel.recv() => {}
+                        _ = tokio::time::sleep_until(retry_at) => {
+                            break;
+                        }
+                    }
+                }
                 continue;
             }
 

--- a/tests/tcp_hdlc_test.rs
+++ b/tests/tcp_hdlc_test.rs
@@ -1,3 +1,6 @@
+use std::sync::Once;
+use std::time::Duration;
+
 use rand_core::OsRng;
 use reticulum::{
     identity::PrivateIdentity,
@@ -6,6 +9,22 @@ use reticulum::{
     transport::{Transport, TransportConfig},
 };
 use tokio_util::sync::CancellationToken;
+
+static INIT: Once = Once::new();
+
+fn setup() {
+    INIT.call_once(|| {
+        env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("trace")).init()
+    });
+}
+
+fn free_local_addr() -> String {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .to_string()
+}
 
 async fn build_transport(name: &str, server_addr: &str, client_addr: &[&str]) -> Transport {
     let transport = Transport::new(TransportConfig::new(
@@ -34,7 +53,7 @@ async fn build_transport(name: &str, server_addr: &str, client_addr: &[&str]) ->
 
 #[tokio::test]
 async fn packet_overload() {
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("trace")).init();
+    setup();
 
     let transport_a = build_transport("a", "127.0.0.1:8081", &[]).await;
     let transport_b = build_transport("b", "127.0.0.1:8082", &["127.0.0.1:8081"]).await;
@@ -101,4 +120,43 @@ async fn packet_overload() {
     let rx_counter = consumer_task.await.unwrap();
 
     log::info!("TX: {}, RX: {}", tx_counter, rx_counter);
+}
+
+#[tokio::test]
+async fn unavailable_tcp_client_does_not_block_server_traffic() {
+    setup();
+
+    let server_addr_a = free_local_addr();
+    let server_addr_b = free_local_addr();
+    let unavailable_addr = free_local_addr();
+
+    let transport_a = build_transport("a", &server_addr_a, &[&unavailable_addr]).await;
+    let transport_b = build_transport("b", &server_addr_b, &[&server_addr_a]).await;
+
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    let sender = tokio::spawn(async move {
+        for counter in 0..3u8 {
+            let mut packet = Packet::default();
+            packet.data.write(&[counter]).unwrap();
+            transport_a.send_packet(packet).await;
+        }
+    });
+
+    tokio::time::timeout(Duration::from_secs(2), sender)
+        .await
+        .expect("send_packet stalled behind an unavailable TCP client")
+        .unwrap();
+
+    let mut iface_rx = transport_b.iface_rx();
+    let mut received = 0usize;
+
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while received < 3 {
+            iface_rx.recv().await.unwrap();
+            received += 1;
+        }
+    })
+    .await
+    .expect("TCP server traffic stopped after another TCP client failed to connect");
 }


### PR DESCRIPTION
  * Offline TCPClient Interfaces resulted in nothing draining their outbound queue, stalling all transport traffic
  * Disconnected TcpClient Interfaces now keep draining and dropping outbound messages while reconnecting/backing off
  * Add a test for this situation