### PR TITLE
Start adding tests against Python implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
     needs: check
     env:
       RETICULUM_TEST_PYTHON_DIR: /opt/reticulum
+      PYTHONPATH: /opt/reticulum
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -50,8 +51,6 @@ jobs:
       - name: checkout Reticulum
         run: git clone https://github.com/markqvist/Reticulum.git "$RETICULUM_TEST_PYTHON_DIR"
       - name: verify Reticulum install
-        run: |
-          export PYTHONPATH="$RETICULUM_TEST_PYTHON_DIR"
-          python3 -c "import RNS; print(RNS.__file__)"
+        run: python3 -c "import RNS; print(RNS.__file__)"
       - name: test
         run: cargo test --workspace --all-targets --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,4 +53,4 @@ jobs:
       - name: verify Reticulum install
         run: python3 -c "import RNS; print(RNS.__file__)"
       - name: test
-        run: cargo test --workspace --all-targets --all-features
+        run: cargo test --workspace --all-targets --all-features -- --no-capture

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,13 +37,21 @@ jobs:
     runs-on: ubuntu-latest
     container: rust:1.95
     needs: check
+    env:
+      RETICULUM_TEST_PYTHON_DIR: /opt/reticulum
     steps:
       - name: checkout
         uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
         with:
           cache-all-crates: "true"
-      - name: install build dependencies
-        run: apt-get update && apt-get install -y protobuf-compiler
+      - name: install dependencies
+        run: apt-get update && apt-get install -y git protobuf-compiler python3
+      - name: checkout Reticulum
+        run: git clone https://github.com/markqvist/Reticulum.git "$RETICULUM_TEST_PYTHON_DIR"
+      - name: verify Reticulum install
+        run: |
+          export PYTHONPATH="$RETICULUM_TEST_PYTHON_DIR"
+          python3 -c "import RNS; print(RNS.__file__)"
       - name: test
         run: cargo test --workspace --all-targets --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
     branches: [main, ci]
   pull_request:
     branches: [main, ci]
+  workflow_dispatch:
 
 env:
   RUSTFLAGS: "-D warnings"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,8 @@ jobs:
     container: rust:1.95
     needs: check
     env:
-      RETICULUM_TEST_PYTHON_DIR: /opt/reticulum
-      PYTHONPATH: /opt/reticulum
+      RETICULUM_TEST_PYTHON_DIR: /opt/Reticulum
+      PYTHONPATH: /opt/Reticulum
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -53,4 +53,4 @@ jobs:
       - name: verify Reticulum install
         run: python3 -c "import RNS; print(RNS.__file__)"
       - name: test
-        run: cargo test --workspace --all-targets --all-features -- --no-capture
+        run: cargo test --workspace --all-targets --all-features

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .cache
 **/.DS_Store
-
 /target
-
 .vscode
-
+tests/rns-py-configs/**/interfaces
+tests/rns-py-configs/**/storage

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -974,6 +974,7 @@ dependencies = [
  "rand_core",
  "rmp",
  "serde",
+ "serde_json",
  "sha2",
  "tokio",
  "tokio-stream",
@@ -1042,22 +1043,45 @@ checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -1506,3 +1530,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ env_logger = "0.10"
 default = ["alloc"]
 alloc = []
 fernet-aes128 = []
+python-tests = []
 
 [build-dependencies]
 tonic-build = "0.13.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ fernet-aes128 = []
 tonic-build = "0.13.0"
 
 [dev-dependencies]
+serde_json = "1.0.150"
 tokio = { version = "1.44.2", features = ["test-util"] }
 
 [[example]]

--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ cargo run --example kaonic_client
 * 🚁 UAV-to-ground resilient C2 and telemetry
 * 🧱 Decentralized infrastructure-free messaging
 
+## Integration tests
+
+Integration tests that run against the Python RNS reference implementation (`tests/python.rs`)
+require the Reticulum source to be checked out and the path set in the `RETICULUM_TEST_PYTHON_DIR`
+environment variable.
+
 ## License
 
 This project is licensed under the MIT license.

--- a/README.md
+++ b/README.md
@@ -66,18 +66,21 @@ cargo run --example tcp_client
 cargo run --example kaonic_client
 ```
 
+### Python integration tests
+
+Integration tests against the Python implementation can be run with the `python-tests` feature and
+setting the `RETICULUM_TEST_PYTHON_DIR` environment variable to the location of the checked out
+Python Reticulum source tree. Example:
+```
+RETICULUM_TEST_PYTHON_DIR=../Reticulum cargo test python --features="python-tests"
+```
+
 ## Use Cases
 
 * 🛰 Tactical radio mesh with Kaonic
 * 🕵️‍♂️ Covert communication using serial or sub-GHz transceivers
 * 🚁 UAV-to-ground resilient C2 and telemetry
 * 🧱 Decentralized infrastructure-free messaging
-
-## Integration tests
-
-Integration tests that run against the Python RNS reference implementation (`tests/python.rs`)
-require the Reticulum source to be checked out and the path set in the `RETICULUM_TEST_PYTHON_DIR`
-environment variable.
 
 ## License
 

--- a/tests/python.rs
+++ b/tests/python.rs
@@ -28,7 +28,9 @@ async fn python_announce() {
     setup();
 
     let script_path = format!("{}/Examples/Announce.py", *RETICULUM_PYTHON_DIR);
-    // the Python example will send application data with the announce from one of these lists
+    // the Python example will send application data with the announce from one of these lists:
+    // fruits = ["Peach", "Quince", "Date", "Tangerine", "Pomelo", "Carambola", "Grape"]
+    // noble_gases = ["Helium", "Neon", "Argon", "Krypton", "Xenon", "Radon", "Oganesson"]
     let get_list = |name| -> Vec<String> {
         let starts_with = format!("{name} = ");
         let content = std::fs::read_to_string(&script_path).expect("failed to read Python script");
@@ -38,14 +40,11 @@ async fn python_announce() {
         let json = &line[starts_with.len()..];
         serde_json::from_str(json).expect("failed to parse fruits list as JSON")
     };
-
     let fruits = get_list ("fruits");
     let noble_gases = get_list ("noble_gases");
 
-    // Find this line in script_path and parse it:
-    // fruits = ["Peach", "Quince", "Date", "Tangerine", "Pomelo", "Carambola", "Grape"]
-
     let mut child = Command::new("python3")
+        .arg("-u")  // make sure output is not buffered
         .arg(script_path)
         .arg("--config")
         .arg("tests/rns-py-configs/udp")
@@ -94,7 +93,7 @@ async fn python_announce() {
             panic!("Python exited early: {status}");
         }
         if let Some(stdin) = child.stdin.as_mut() {
-            stdin.write_all(b"\n").unwrap(); // Simulates pressing Return
+            stdin.write_all(b"\n").unwrap(); // simulates pressing Return
             stdin.flush().unwrap();
         }
         time::sleep(time::Duration::from_secs(1)).await;

--- a/tests/python.rs
+++ b/tests/python.rs
@@ -1,0 +1,109 @@
+use std::process::{Command, Stdio};
+use std::sync::{LazyLock, Once};
+
+use tokio::time;
+
+use reticulum::iface::udp::UdpInterface;
+use reticulum::transport::TransportConfig;
+
+static RETICULUM_PYTHON_DIR: LazyLock<String> =
+    LazyLock::new(|| std::env::var("RETICULUM_TEST_PYTHON_DIR").unwrap());
+
+static INIT: Once = Once::new();
+
+fn setup() {
+    INIT.call_once(|| {
+        env_logger::Builder::from_env(
+            env_logger::Env::default().default_filter_or("trace")
+        ).init()
+    });
+}
+
+#[tokio::test]
+/// Spawn Python Reticulum Example/Announce.py and listen for announce
+async fn python_announce() {
+    use std::io::Write;
+    setup();
+
+    let script_path = format!("{}/Examples/Announce.py", *RETICULUM_PYTHON_DIR);
+    // the Python example will send application data with the announce from one of these lists
+    let get_list = |name| -> Vec<String> {
+        let starts_with = format!("{name} = ");
+        let content = std::fs::read_to_string(&script_path).expect("failed to read Python script");
+        let line = content.lines()
+            .find(|l| l.starts_with(&starts_with))
+            .expect("could not find fruits list in script");
+        let json = &line[starts_with.len()..];
+        serde_json::from_str(json).expect("failed to parse fruits list as JSON")
+    };
+
+    let fruits = get_list ("fruits");
+    let noble_gases = get_list ("noble_gases");
+
+    // Find this line in script_path and parse it:
+    // fruits = ["Peach", "Quince", "Date", "Tangerine", "Pomelo", "Carambola", "Grape"]
+
+    let mut child = Command::new("python3")
+        .arg(script_path)
+        .arg("--config")
+        .arg("tests/rns-py-configs/udp")
+        .stdin(Stdio::piped())  // to be able to send to stdin
+        .spawn()
+        .expect("failed to start Announce.py");
+
+    let transport = TransportConfig::default().build();
+    let _ = transport.iface_manager().lock().await.spawn(
+        UdpInterface::new("0.0.0.0:4242", Some("127.0.0.1:4243")),
+        UdpInterface::spawn);
+    let mut recv_announces = transport.recv_announces().await;
+    let handle = tokio::spawn(async move {
+        let mut counter = 0;
+        while counter < 2 {
+            // wait for 10 seconds to receive announce, otherwise exit with error
+            let result = time::timeout(time::Duration::from_secs(10), recv_announces.recv()).await;
+            match result {
+                Ok(Ok(announce)) => {
+                    let app_data = str::from_utf8(announce.app_data.as_slice()).unwrap().to_string();
+                    log::info!("got announce {}: {app_data}",
+                        announce.destination.lock().await.desc.address_hash);
+                    if counter == 0 {
+                        assert!(fruits.contains(&app_data));
+                    } else {
+                        debug_assert_eq!(counter, 1);
+                        assert!(noble_gases.contains(&app_data));
+                    }
+                    counter += 1;
+                }
+                Ok(Err(err)) => {
+                    log::error!("error waiting for announce: {err}");
+                    panic!("error waiting for announce: {err}");
+                }
+                Err(_) => {
+                    log::error!("error waiting for announce: timeout");
+                    panic!("error waiting for announce: timeout");
+                }
+            }
+        }
+    });
+
+    while !handle.is_finished() {
+        if let Some(status) = child.try_wait().unwrap() {
+            handle.abort();
+            panic!("Python exited early: {status}");
+        }
+        if let Some(stdin) = child.stdin.as_mut() {
+            stdin.write_all(b"\n").unwrap(); // Simulates pressing Return
+            stdin.flush().unwrap();
+        }
+        time::sleep(time::Duration::from_secs(1)).await;
+    }
+    handle.await.expect("failed to receive announce");
+    let _ = child.kill();
+    match tokio::time::timeout(
+        time::Duration::from_secs(5),
+        tokio::task::spawn_blocking(move || child.wait())
+    ).await {
+        Ok(Ok(Ok(status))) => log::debug!("Python exited with: {status}"),
+        _ => log::warn!("Python did not exit cleanly after kill")
+    }
+}

--- a/tests/python.rs
+++ b/tests/python.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "python-tests")]
+
 use std::process::{Command, Stdio};
 use std::sync::{LazyLock, Once};
 

--- a/tests/python.rs
+++ b/tests/python.rs
@@ -99,7 +99,7 @@ async fn python_announce() {
         }
         time::sleep(time::Duration::from_secs(1)).await;
     }
-    handle.await.expect("failed to receive announce");
+    handle.await.expect("receive announce task failure");
     let _ = child.kill();
     match tokio::time::timeout(
         time::Duration::from_secs(5),

--- a/tests/rns-py-configs/udp/config
+++ b/tests/rns-py-configs/udp/config
@@ -1,0 +1,120 @@
+# This is the default Reticulum config file.
+# You should probably edit it to include any additional,
+# interfaces and settings you might need.
+
+# Only the most basic options are included in this default
+# configuration. To see a more verbose, and much longer,
+# configuration example, you can run the command:
+# rnsd --exampleconfig
+
+
+[reticulum]
+  discover_interfaces = Yes
+  
+  # If you enable Transport, your system will route traffic
+  # for other peers, pass announces and serve path requests.
+  # This should only be done for systems that are suited to
+  # act as transport nodes, ie. if they are stationary and
+  # always-on. This directive is optional and can be removed
+  # for brevity.
+  
+  enable_transport = True
+  
+  
+  # By default, the first program to launch the Reticulum
+  # Network Stack will create a shared instance, that other
+  # programs can communicate with. Only the shared instance
+  # opens all the configured interfaces directly, and other
+  # local programs communicate with the shared instance over
+  # a local socket. This is completely transparent to the
+  # user, and should generally be turned on. This directive
+  # is optional and can be removed for brevity.
+  
+  share_instance = Yes
+  
+  
+  # If you want to run multiple *different* shared instances
+  # on the same system, you will need to specify different
+  # instance names for each. On platforms supporting domain
+  # sockets, this can be done with the instance_name option:
+  
+  instance_name = default
+
+# Some platforms don't support domain sockets, and if that
+# is the case, you can isolate different instances by
+# specifying a unique set of ports for each:
+
+# shared_instance_port = 37428
+# instance_control_port = 37429
+
+
+# If you want to explicitly use TCP for shared instance
+# communication, instead of domain sockets, this is also
+# possible, by using the following option:
+
+# shared_instance_type = tcp
+
+
+# You can configure Reticulum to panic and forcibly close
+# if an unrecoverable interface error occurs, such as the
+# hardware device for an interface disappearing. This is
+# an optional directive, and can be left out for brevity.
+# This behaviour is disabled by default.
+
+# panic_on_interface_error = No
+
+
+[logging]
+  # Valid log levels are 0 through 7:
+  #   0: Log only critical information
+  #   1: Log errors and lower log levels
+  #   2: Log warnings and lower log levels
+  #   3: Log notices and lower log levels
+  #   4: Log info and lower (this is the default)
+  #   5: Verbose logging
+  #   6: Debug logging
+  #   7: Extreme logging
+  
+  loglevel = 4
+
+
+# The interfaces section defines the physical and virtual
+# interfaces Reticulum will use to communicate on. This
+# section will contain examples for a variety of interface
+# types. You can modify these or use them as a basis for
+# your own config, or simply remove the unused ones.
+
+[interfaces]
+  
+  # This interface enables communication with other
+  # link-local Reticulum nodes over UDP. It does not
+  # need any functional IP infrastructure like routers
+  # or DHCP servers, but will require that at least link-
+  # local IPv6 is enabled in your operating system, which
+  # should be enabled by default in almost any OS. See
+  # the Reticulum Manual for more configuration options.
+  
+  [[Default Interface]]
+    type = AutoInterface
+    enabled = No
+
+# [[RNS TCP Node Germany 001]]
+#   type = TCPClientInterface
+#   enabled = yes
+#   target_host = 202.61.243.41
+#   target_port = 4965
+
+# [[Mynode]]
+#   type = TCPServerInterface
+#   enabled = yes
+#   listen_ip = 127.0.0.1
+#   listen_port = 4243
+
+[[UDP Interface]]
+  type = UDPInterface
+  enabled = yes
+  listen_ip = 0.0.0.0
+  listen_port = 4243
+  #forward_ip = 255.255.255.255
+  forward_ip = 127.0.0.1
+  forward_port = 4242

--- a/tests/rns-py-configs/udp/config
+++ b/tests/rns-py-configs/udp/config
@@ -9,7 +9,7 @@
 
 
 [reticulum]
-  discover_interfaces = Yes
+  discover_interfaces = No
   
   # If you enable Transport, your system will route traffic
   # for other peers, pass announces and serve path requests.


### PR DESCRIPTION
Adds an integration test for running against Python Reticulum. Feature gated behind `python-tests` feature. Set `RETICULUM_TEST_PYTHON_DIR` to point to checked out Reticulum code.

Added steps to CI workflow to run the tests.