### PR TITLE
ci: add timeout-minutes to jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     container: rust:1.95
+    timeout-minutes: 5
 
     steps:
       - name: checkout
@@ -37,6 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     container: rust:1.95
     needs: check
+    timeout-minutes: 10
     env:
       RETICULUM_TEST_PYTHON_DIR: /opt/Reticulum
       PYTHONPATH: /opt/Reticulum


### PR DESCRIPTION
Add timeout for jobs. Currently check job timeout is set to 5 minutes and test job timeout is set to 10 minutes.