### PR TITLE
Python link tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,9 @@ jobs:
       - name: install dependencies
         run: apt-get update && apt-get install -y git protobuf-compiler python3
       - name: checkout Reticulum
-        run: git clone https://github.com/markqvist/Reticulum.git "$RETICULUM_TEST_PYTHON_DIR"
+        run: |
+          git clone https://github.com/markqvist/Reticulum.git "$RETICULUM_TEST_PYTHON_DIR"
+          echo "Reticulum rev $(cd $RETICULUM_TEST_PYTHON_DIR && git rev-parse HEAD)"
       - name: verify Reticulum install
         run: python3 -c "import RNS; print(RNS.__file__)"
       - name: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,4 +55,4 @@ jobs:
       - name: verify Reticulum install
         run: python3 -c "import RNS; print(RNS.__file__)"
       - name: test
-        run: cargo test --workspace --all-targets --all-features
+        run: cargo test --workspace --all-targets --features="python-tests"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,4 +55,4 @@ jobs:
       - name: verify Reticulum install
         run: python3 -c "import RNS; print(RNS.__file__)"
       - name: test
-        run: cargo test --workspace --all-targets --features="python-tests"
+        run: cargo test --workspace --all-targets --features="python-tests" -- --no-capture

--- a/src/destination/link.rs
+++ b/src/destination/link.rs
@@ -303,8 +303,8 @@ impl Link {
             PacketContext::LinkRTT if !out_link => {
                 let mut buffer = [0u8; PACKET_MDU];
                 if let Ok(plain_text) = self.decrypt(packet.data.as_slice(), &mut buffer[..]) {
-                    if let Ok(rtt) = rmp::decode::read_f32(&mut &plain_text[..]) {
-                        self.rtt = Duration::from_secs_f32(rtt);
+                    if let Ok(rtt) = rmp::decode::read_f64(&mut &plain_text[..]) {
+                        self.rtt = Duration::from_secs_f64(rtt);
                     } else {
                         log::error!("link({}): failed to decode rtt", self.id);
                     }
@@ -471,12 +471,9 @@ impl Link {
     }
 
     pub fn create_rtt(&self) -> Packet {
-        let rtt = self.rtt.as_secs_f32();
-        let mut buf = Vec::new();
-        {
-            buf.reserve(4);
-            rmp::encode::write_f32(&mut buf, rtt).unwrap();
-        }
+        let rtt = self.rtt.as_secs_f64();
+        let mut buf = Vec::with_capacity(9);
+        rmp::encode::write_f64(&mut buf, rtt).unwrap();
 
         let mut packet_data = PacketDataBuffer::new();
 

--- a/tests/python.rs
+++ b/tests/python.rs
@@ -128,6 +128,7 @@ async fn python_link_client() {
         .arg("--server")
         .arg("--config")
         .arg("tests/rns-py-configs/udp")
+        .stdin(Stdio::piped())  // we do not send to stdin in this example but to prevent EOF error
         .stdout(Stdio::piped())  // to be able to process stdout lines
         .spawn()
         .expect("failed to start {script_path}");

--- a/tests/python.rs
+++ b/tests/python.rs
@@ -1,30 +1,34 @@
 #![cfg(feature = "python-tests")]
 
 use std::process::{Command, Stdio};
-use std::sync::{LazyLock, Once};
+use std::sync::{mpsc, LazyLock, Once};
 
+use tokio::sync::Mutex;
 use tokio::time;
 
+use reticulum::hash::AddressHash;
 use reticulum::iface::udp::UdpInterface;
+use reticulum::destination::link::LinkEvent;
 use reticulum::transport::TransportConfig;
 
 static RETICULUM_PYTHON_DIR: LazyLock<String> =
     LazyLock::new(|| std::env::var("RETICULUM_TEST_PYTHON_DIR").unwrap());
 
 static INIT: Once = Once::new();
+/// Only one test can be running at a time
+static TEST_MUTEX: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
 fn setup() {
-    INIT.call_once(|| {
-        env_logger::Builder::from_env(
-            env_logger::Env::default().default_filter_or("trace")
-        ).init()
-    });
+    INIT.call_once(||
+        env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("trace")).init()
+    );
 }
 
 #[tokio::test]
 /// Spawn Python Reticulum Example/Announce.py and listen for announce
 async fn python_announce() {
     use std::io::Write;
+    let _guard = TEST_MUTEX.lock().await;
     setup();
 
     let script_path = format!("{}/Examples/Announce.py", *RETICULUM_PYTHON_DIR);
@@ -106,5 +110,117 @@ async fn python_announce() {
     ).await {
         Ok(Ok(Ok(status))) => log::debug!("Python exited with: {status}"),
         _ => log::warn!("Python did not exit cleanly after kill")
+    }
+}
+
+#[tokio::test]
+/// Spawn Python Reticulum Example/Link.py and exchange messages
+async fn python_link() {
+    use std::io::BufRead;
+    let _guard = TEST_MUTEX.lock().await;
+    setup();
+
+    let script_path = format!("{}/Examples/Link.py", *RETICULUM_PYTHON_DIR);
+    // the Python example will send application data with the announce from one of these lists:
+    // fruits = ["Peach", "Quince", "Date", "Tangerine", "Pomelo", "Carambola", "Grape"]
+    // noble_gases = ["Helium", "Neon", "Argon", "Krypton", "Xenon", "Radon", "Oganesson"]
+
+    let mut child = Command::new("python3")
+        .arg("-u")  // make sure output is not buffered
+        .arg(script_path)
+        .arg("--server")
+        .arg("--config")
+        .arg("tests/rns-py-configs/udp")
+        .stdin(Stdio::piped())   // to be able to send to stdin
+        .stdout(Stdio::piped())  // to be able to process stdout lines
+        .spawn()
+        .expect("failed to start Announce.py");
+    let (tx, rx) = mpsc::channel();
+    let stdout = child.stdout.take().expect("child process has no stdout");
+    // forward stdout and return server destination hash
+    let stdout_handle = std::thread::spawn(move || {
+        for line in std::io::BufReader::new(stdout).lines() {
+            let line = line.unwrap();
+            println!("{line}");
+            // parse the hash from:
+            // [2026-06-03 12:03:33] [Notice]   Link example <5d3a09e13b866e49624d1bb576c23976> running, waiting for a connection.
+            if let Some ((index, _)) = line.match_indices(']').nth(1) {
+                let msg = line.split_at(index+1).1.trim();
+                if let Some(hash_start) = msg.strip_prefix("Link example <") {
+                    if let Some(hash_end) = hash_start.find('>') {
+                        let hash = AddressHash::new_from_hex_string(&hash_start[..hash_end])
+                            .expect("failed to parse server destination hash");
+                        if tx.send(hash).is_err() {
+                            log::debug!("child process hash channel closed");
+                            break
+                        }
+                    } else {
+                        let err = "could not parse server destination hash".to_string();
+                        log::error!("{err}");
+                        return Err(err)
+                    }
+                }
+            }
+        }
+        Ok(())
+    });
+    let server_hash = rx.recv().expect("child process sender hung up");
+    log::info!("got server destination hash: {server_hash}");
+    let transport = TransportConfig::default().build();
+    let _ = transport.iface_manager().lock().await.spawn(
+        UdpInterface::new("0.0.0.0:4242", Some("127.0.0.1:4243")),
+        UdpInterface::spawn);
+    let mut recv_announces = transport.recv_announces().await;
+    // request announce
+    transport.request_path(&server_hash, None, None).await;
+    // wait for 10 seconds to receive announce, otherwise exit with error
+    let result = time::timeout(time::Duration::from_secs(10), recv_announces.recv()).await;
+    let server_dest = match result {
+        Ok(Ok(announce)) => announce.destination.clone(),
+        Ok(Err(err)) => panic!("error waiting for announce: {err}"),
+        Err(_) => panic!("error waiting for announce: timeout")
+    };
+    log::debug!("got server destination: {}", server_dest.lock().await.desc.address_hash);
+    // create link
+    let mut out_link_events = transport.out_link_events();
+    let link = transport.link(server_dest.lock().await.desc).await;
+    loop {
+        match out_link_events.recv().await {
+            Ok(event) => match event.event {
+                LinkEvent::Activated => {
+                    // send data
+                    log::debug!("link activated: sending data");
+                    let packet = match link.lock().await.data_packet(b"test") {
+                        Ok(packet) => packet,
+                        Err(err) => panic!("error creating data packet: {err:?}")
+                    };
+                    transport.send_packet(packet).await;
+                }
+                LinkEvent::Data(payload) => {
+                    log::debug!("got payload: {:?}", str::from_utf8(payload.as_slice()));
+                    assert_eq!(payload.as_slice(),
+                      b"I received \"test\" over the link");
+                    // succeeded: shut down
+                    break
+                }
+                LinkEvent::Proof(_) => {}
+                LinkEvent::Closed => panic!("error: link closed unexpectedly")
+            }
+            Err(err) => panic!("error receiving out link events: {err}")
+        }
+    }
+    // shutdown
+    let _ = child.kill();
+    match tokio::time::timeout(
+        time::Duration::from_secs(5),
+        tokio::task::spawn_blocking(move || child.wait())
+    ).await {
+        Ok(Ok(Ok(status))) => log::debug!("Python exited with: {status}"),
+        _ => log::warn!("Python did not exit cleanly after kill")
+    }
+    match stdout_handle.join() {
+        Ok(Ok(())) => log::debug!("child stdout thread finished normally"),
+        Ok(Err(err)) => panic!("error in child stdout thread: {err}"),
+        Err(err) => panic!("child stdout thread failed to join: {err:?}")
     }
 }

--- a/tests/python.rs
+++ b/tests/python.rs
@@ -186,8 +186,8 @@ async fn python_link_client() {
     let mut out_link_events = transport.out_link_events();
     let link = transport.link(server_dest.lock().await.desc).await;
     loop {
-        match out_link_events.recv().await {
-            Ok(event) => match event.event {
+        match tokio::time::timeout(time::Duration::from_secs(5), out_link_events.recv()).await {
+            Ok(Ok(event)) => match event.event {
                 LinkEvent::Activated => {
                     // send data
                     log::debug!("link activated: sending data");
@@ -207,7 +207,8 @@ async fn python_link_client() {
                 LinkEvent::Proof(_) => {}
                 LinkEvent::Closed => panic!("error: link closed unexpectedly")
             }
-            Err(err) => panic!("error receiving out link events: {err}")
+            Ok(Err(err)) => panic!("error receiving out link events: {err}"),
+            Err(err) => panic!("timed out recieving out link events: {err}")
         }
     }
     // shutdown

--- a/tests/python.rs
+++ b/tests/python.rs
@@ -1,14 +1,17 @@
 #![cfg(feature = "python-tests")]
 
 use std::process::Stdio;
-use std::sync::{LazyLock, Once};
+use std::sync::{atomic, LazyLock, Once};
 
 use tokio::process::Command;
-use tokio::sync::{mpsc, Mutex};
+use tokio::sync::{broadcast, mpsc, Mutex};
+use tokio::task::JoinHandle;
 use tokio::time;
 
 use reticulum::hash::AddressHash;
+use reticulum::identity::PrivateIdentity;
 use reticulum::iface::udp::UdpInterface;
+use reticulum::destination::DestinationName;
 use reticulum::destination::link::LinkEvent;
 use reticulum::transport::TransportConfig;
 
@@ -97,23 +100,22 @@ async fn python_announce() {
             handle.abort();
             panic!("Python exited early: {status}");
         }
-        if let Some(stdin) = child.stdin.as_mut() {
-            stdin.write_all(b"\n").await.unwrap(); // simulates pressing Return
-            stdin.flush().await.unwrap();
-        }
+        let stdin = child.stdin.as_mut().expect("child stdin not present");
+        stdin.write_all(b"\n").await.unwrap(); // simulates pressing Return
+        stdin.flush().await.unwrap();
         time::sleep(time::Duration::from_secs(1)).await;
     }
     handle.await.expect("receive announce task failure");
     let _ = child.start_kill();
     match tokio::time::timeout(time::Duration::from_secs(5), child.wait()).await {
         Ok(Ok(status)) => log::debug!("Python exited with: {status}"),
-        _ => log::warn!("Python did not exit cleanly after kill")
+        _ => panic!("Python did not exit cleanly after kill")
     }
 }
 
 #[tokio::test]
-/// Spawn Python Reticulum Example/Link.py and exchange messages
-async fn python_link() {
+/// Spawn Python Reticulum Example/Link.py as server and exchange messages as client
+async fn python_link_client() {
     use tokio::io::AsyncBufReadExt;
     let _guard = TEST_MUTEX.lock().await;
     setup();
@@ -126,7 +128,6 @@ async fn python_link() {
         .arg("--server")
         .arg("--config")
         .arg("tests/rns-py-configs/udp")
-        .stdin(Stdio::piped())   // to be able to send to stdin
         .stdout(Stdio::piped())  // to be able to process stdout lines
         .spawn()
         .expect("failed to start Announce.py");
@@ -213,11 +214,142 @@ async fn python_link() {
     let _ = child.start_kill();
     match tokio::time::timeout(time::Duration::from_secs(5), child.wait()).await {
         Ok(Ok(status)) => log::debug!("Python exited with: {status}"),
-        _ => log::warn!("Python did not exit cleanly after kill")
+        _ => panic!("Python did not exit cleanly after kill")
     }
     match stdout_handle.await {
-        Ok(Ok(())) => log::debug!("child stdout thread finished normally"),
-        Ok(Err(err)) => panic!("error in child stdout thread: {err}"),
-        Err(err) => panic!("child stdout thread failed to join: {err:?}")
+        Ok(Ok(())) => log::debug!("child stdout task finished normally"),
+        Ok(Err(err)) => panic!("error in child stdout task: {err}"),
+        Err(err) => panic!("child stdout task failed to join: {err:?}")
+    }
+}
+
+#[tokio::test]
+/// Create server and run Python Reticulum Example/Link.py as client and send messages
+async fn python_link_server() {
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
+    let _guard = TEST_MUTEX.lock().await;
+    setup();
+
+    let server_identity = PrivateIdentity::new_from_rand(rand_core::OsRng);
+    //let server_identity = PrivateIdentity::new_from_name("test-python-link-server");
+    let mut transport = TransportConfig::default().build();
+    let _ = transport.iface_manager().lock().await.spawn(
+        UdpInterface::new("0.0.0.0:4242", Some("127.0.0.1:4243")),
+        UdpInterface::spawn);
+    let destination = transport
+        .add_destination(server_identity, DestinationName::new("example_utilities", "linkexample"))
+        .await;
+    let destination_hash = destination.lock().await.desc.address_hash;
+    log::info!("created server destination: {destination_hash}");
+    log::info!("created server destination: {:?}", destination_hash.as_slice());
+    let mut in_link_events = transport.in_link_events();
+
+    let script_path = format!("{}/Examples/Link.py", *RETICULUM_PYTHON_DIR);
+
+    let mut child = Command::new("python3")
+        .arg("-u")  // make sure output is not buffered
+        .arg(script_path)
+        .arg("--config")
+        .arg("tests/rns-py-configs/udp")
+        .arg(destination_hash.to_string().trim_matches('/'))
+        .stdin(Stdio::piped())   // to be able to send to stdin
+        .stdout(Stdio::piped())  // to be able to process stdout lines
+        .spawn()
+        .expect("failed to start Announce.py");
+    let stdout = child.stdout.take().expect("child process has no stdout");
+    static RUNNING: atomic::AtomicBool = atomic::AtomicBool::new(true);
+    static READY_TO_SEND: atomic::AtomicBool = atomic::AtomicBool::new(false);
+    // forward stdout and exit when reply is received
+    let stdout_handle: JoinHandle<Result<(), String>> = tokio::spawn(async move {
+        let mut lines = tokio::io::BufReader::new(stdout).lines();
+        // when the child process is killed next_line() will return None
+        while let Some(line) = lines.next_line().await.map_err(|err|{
+            let err = format!("error iterating over child stdout lines: {err}");
+            log::error!("{err}");
+            err
+        })? {
+            println!("{line}");
+            // test complete when client outputs:
+            // [2026-06-05 23:03:30] [Notice]   Received data on the link: I received "test" over the link
+            if let Some ((index, _)) = line.match_indices(']').nth(1) {
+                let msg = line.split_at(index+1).1.trim();
+                if msg == "Link established with server, enter some text to send, or \"quit\" to quit" {
+                    // ready to send message
+                    READY_TO_SEND.store(true, atomic::Ordering::SeqCst);
+                } else if msg == "Received data on the link: I received \"test\" over the link" {
+                    // test complete
+                    log::info!("client got reply, breaking stdout loop");
+                    RUNNING.store(false, atomic::Ordering::SeqCst);
+                    break
+                }
+            }
+        }
+        Ok(())
+    });
+    let link_task = tokio::spawn(async move {
+        while RUNNING.load(atomic::Ordering::SeqCst) {
+            match in_link_events.try_recv() {
+                Ok(event) => match event.event {
+                    LinkEvent::Activated => log::debug!("link activated {}", event.id),
+                    LinkEvent::Data(payload) => {
+                        let payload = str::from_utf8(payload.as_slice()).unwrap();
+                        log::info!("got payload: {payload:?}");
+                        // send reply
+                        let msg = format!("I received \"{payload}\" over the link");
+                        let link = transport.find_in_link(&event.id).await
+                            .expect("couldn't find in link");
+                        let packet = match link.lock().await.data_packet(msg.as_bytes()) {
+                            Ok(packet) => packet,
+                            Err(err) => panic!("error creating data packet: {err:?}")
+                        };
+                        transport.send_packet(packet).await;
+                    }
+                    LinkEvent::Proof(_) => {}
+                    LinkEvent::Closed => panic!("error: link closed unexpectedly")
+                }
+                Err(broadcast::error::TryRecvError::Empty) => {}
+                Err(err) => panic!("error receiving in link events: {err}")
+            }
+            time::sleep(time::Duration::from_millis(100)).await;
+        }
+    });
+    let t_start = time::Instant::now();
+    while !READY_TO_SEND.load(atomic::Ordering::SeqCst) {
+        if t_start.elapsed() > time::Duration::from_secs(10) {
+            let _ = child.start_kill();
+            panic!("child stdout did not signal ready to send after 10 seconds");
+        }
+        time::sleep(time::Duration::from_millis(100)).await;
+    }
+    // send message
+    {
+        let stdin = child.stdin.as_mut().expect("child stdin not present");
+        stdin.write_all(b"test\n").await.unwrap();
+        stdin.flush().await.unwrap();
+    }
+    // wait for finish
+    let t_start = time::Instant::now();
+    while !stdout_handle.is_finished() {
+        if t_start.elapsed() > time::Duration::from_secs(10) {
+            let _ = child.start_kill();
+            panic!("child stdout loop did not exit after 10 seconds");
+        }
+        time::sleep(time::Duration::from_millis(100)).await;
+    }
+    match stdout_handle.await {
+        Ok(Ok(())) => log::debug!("child stdout task finished normally"),
+        Ok(Err(err)) => panic!("error in child stdout task: {err}"),
+        Err(err) => panic!("child stdout task failed to join: {err:?}")
+    }
+    match tokio::time::timeout(time::Duration::from_secs(5), link_task).await {
+        Ok(Ok(())) => log::debug!("link task finished normally"),
+        Ok(Err(err)) => panic!("link task failed to join: {err:?}"),
+        Err(err) => panic!("timed out waiting for link task: {err:?}")
+    }
+    // shutdown
+    let _ = child.start_kill();
+    match tokio::time::timeout(time::Duration::from_secs(5), child.wait()).await {
+        Ok(Ok(status)) => log::debug!("Python exited with: {status}"),
+        _ => panic!("Python did not exit cleanly after kill")
     }
 }

--- a/tests/python.rs
+++ b/tests/python.rs
@@ -58,7 +58,7 @@ async fn python_announce() {
         .arg("tests/rns-py-configs/udp")
         .stdin(Stdio::piped())  // to be able to send to stdin
         .spawn()
-        .expect("failed to start Announce.py");
+        .expect("failed to start {script_path}");
 
     let transport = TransportConfig::default().build();
     let _ = transport.iface_manager().lock().await.spawn(
@@ -130,7 +130,7 @@ async fn python_link_client() {
         .arg("tests/rns-py-configs/udp")
         .stdout(Stdio::piped())  // to be able to process stdout lines
         .spawn()
-        .expect("failed to start Announce.py");
+        .expect("failed to start {script_path}");
     let (tx, mut rx) = mpsc::unbounded_channel();
     let stdout = child.stdout.take().expect("child process has no stdout");
     // forward stdout and return server destination hash
@@ -256,7 +256,7 @@ async fn python_link_server() {
         .stdin(Stdio::piped())   // to be able to send to stdin
         .stdout(Stdio::piped())  // to be able to process stdout lines
         .spawn()
-        .expect("failed to start Announce.py");
+        .expect("failed to start {script_path}");
     let stdout = child.stdout.take().expect("child process has no stdout");
     static RUNNING: atomic::AtomicBool = atomic::AtomicBool::new(true);
     static READY_TO_SEND: atomic::AtomicBool = atomic::AtomicBool::new(false);

--- a/tests/python.rs
+++ b/tests/python.rs
@@ -1,9 +1,10 @@
 #![cfg(feature = "python-tests")]
 
-use std::process::{Command, Stdio};
-use std::sync::{mpsc, LazyLock, Once};
+use std::process::Stdio;
+use std::sync::{LazyLock, Once};
 
-use tokio::sync::Mutex;
+use tokio::process::Command;
+use tokio::sync::{mpsc, Mutex};
 use tokio::time;
 
 use reticulum::hash::AddressHash;
@@ -27,7 +28,7 @@ fn setup() {
 #[tokio::test]
 /// Spawn Python Reticulum Example/Announce.py and listen for announce
 async fn python_announce() {
-    use std::io::Write;
+    use tokio::io::AsyncWriteExt;
     let _guard = TEST_MUTEX.lock().await;
     setup();
 
@@ -97,18 +98,15 @@ async fn python_announce() {
             panic!("Python exited early: {status}");
         }
         if let Some(stdin) = child.stdin.as_mut() {
-            stdin.write_all(b"\n").unwrap(); // simulates pressing Return
-            stdin.flush().unwrap();
+            stdin.write_all(b"\n").await.unwrap(); // simulates pressing Return
+            stdin.flush().await.unwrap();
         }
         time::sleep(time::Duration::from_secs(1)).await;
     }
     handle.await.expect("receive announce task failure");
-    let _ = child.kill();
-    match tokio::time::timeout(
-        time::Duration::from_secs(5),
-        tokio::task::spawn_blocking(move || child.wait())
-    ).await {
-        Ok(Ok(Ok(status))) => log::debug!("Python exited with: {status}"),
+    let _ = child.start_kill();
+    match tokio::time::timeout(time::Duration::from_secs(5), child.wait()).await {
+        Ok(Ok(status)) => log::debug!("Python exited with: {status}"),
         _ => log::warn!("Python did not exit cleanly after kill")
     }
 }
@@ -116,14 +114,11 @@ async fn python_announce() {
 #[tokio::test]
 /// Spawn Python Reticulum Example/Link.py and exchange messages
 async fn python_link() {
-    use std::io::BufRead;
+    use tokio::io::AsyncBufReadExt;
     let _guard = TEST_MUTEX.lock().await;
     setup();
 
     let script_path = format!("{}/Examples/Link.py", *RETICULUM_PYTHON_DIR);
-    // the Python example will send application data with the announce from one of these lists:
-    // fruits = ["Peach", "Quince", "Date", "Tangerine", "Pomelo", "Carambola", "Grape"]
-    // noble_gases = ["Helium", "Neon", "Argon", "Krypton", "Xenon", "Radon", "Oganesson"]
 
     let mut child = Command::new("python3")
         .arg("-u")  // make sure output is not buffered
@@ -135,12 +130,17 @@ async fn python_link() {
         .stdout(Stdio::piped())  // to be able to process stdout lines
         .spawn()
         .expect("failed to start Announce.py");
-    let (tx, rx) = mpsc::channel();
+    let (tx, mut rx) = mpsc::unbounded_channel();
     let stdout = child.stdout.take().expect("child process has no stdout");
     // forward stdout and return server destination hash
-    let stdout_handle = std::thread::spawn(move || {
-        for line in std::io::BufReader::new(stdout).lines() {
-            let line = line.unwrap();
+    let stdout_handle = tokio::spawn(async move {
+        let mut lines = tokio::io::BufReader::new(stdout).lines();
+        // when the child process is killed next_line() will return None
+        while let Some(line) = lines.next_line().await.map_err(|err|{
+            let err = format!("error iterating over child stdout lines: {err}");
+            log::error!("{err}");
+            err
+        })? {
             println!("{line}");
             // parse the hash from:
             // [2026-06-03 12:03:33] [Notice]   Link example <5d3a09e13b866e49624d1bb576c23976> running, waiting for a connection.
@@ -164,7 +164,7 @@ async fn python_link() {
         }
         Ok(())
     });
-    let server_hash = rx.recv().expect("child process sender hung up");
+    let server_hash = rx.recv().await.expect("child process sender hung up");
     log::info!("got server destination hash: {server_hash}");
     let transport = TransportConfig::default().build();
     let _ = transport.iface_manager().lock().await.spawn(
@@ -210,15 +210,12 @@ async fn python_link() {
         }
     }
     // shutdown
-    let _ = child.kill();
-    match tokio::time::timeout(
-        time::Duration::from_secs(5),
-        tokio::task::spawn_blocking(move || child.wait())
-    ).await {
-        Ok(Ok(Ok(status))) => log::debug!("Python exited with: {status}"),
+    let _ = child.start_kill();
+    match tokio::time::timeout(time::Duration::from_secs(5), child.wait()).await {
+        Ok(Ok(status)) => log::debug!("Python exited with: {status}"),
         _ => log::warn!("Python did not exit cleanly after kill")
     }
-    match stdout_handle.join() {
+    match stdout_handle.await {
         Ok(Ok(())) => log::debug!("child stdout thread finished normally"),
         Ok(Err(err)) => panic!("error in child stdout thread: {err}"),
         Err(err) => panic!("child stdout thread failed to join: {err:?}")


### PR DESCRIPTION
Adds integration tests as client/server with Python Link.py example.

Also includes a commit that fixes the LinkRTT type to be f64 instead of f32. rmp was not able to decode the Python float (double precision) as f32.