### PR TITLE
test: fix message_proof_over_remote_link test getting stuck

### DIFF
--- a/tests/hop_test.rs
+++ b/tests/hop_test.rs
@@ -163,7 +163,10 @@ async fn message_proof_over_remote_link() {
         .add_destination(id_c, DestinationName::new("test", "link_to"))
         .await;
     let dest_c_hash = dest_c.lock().await.desc.address_hash;
-
+    // NOTE: we have to wait before sending announce because if the TCP client has not yet
+    // connected, the outgoing packet will be dropped
+    // TODO: can we do this without waiting?
+    time::sleep(Duration::from_millis(100)).await;
     transport_c.send_announce(&dest_c, None).await;
 
     transport_a.recv_announces().await.recv().await.unwrap();


### PR DESCRIPTION
Added a small wait before sending announce in message_proof_over_remote_link test. It was getting stuck because the announce was being sent before the TCP clients had a chance to connect, resulting in a dropped packet. Dropping the packet was introduced in the merge of pull #96 (c707920), which drops any incoming packets for the TCP client interface until it has connected.

Added a TODO note to try and refactor to avoid the call to sleep. Some possible solutions:

1. have a way to signal that a TCP client has connected
2. check the recv announce channel to see if it was received, and re-send if not yet received
3. re-think the InterfaceContext channel setup; the reason #96 was needed is becasue the InterfaceContext uses a bounded channel of capacity 1. Channel sends wait until capacity is available, so no further messages will be sent as long as a TCP client is disconnected and the channel is full. If this capacity could be increased then the TCP client could check the capacity before dropping packets to avoid blocking other interfaces.